### PR TITLE
feat(mouse): stock/bisect mouse modes (bisect via digitizer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,17 @@ endif
 
 # Convenience targets — build and flash the Cantor keymap.
 # Flash: put the keyboard in bootloader mode (double-tap reset) before running.
-.PHONY: build flash
+.PHONY: build flash test-bisect
 
 build:
 	qmk compile -kb cantor -km shofel
 
 flash: build
 	dfu-util -d 0483:df11 -a 0 -s 0x08000000:leave -D $(QMK_FIRMWARE_ROOT)/cantor_shofel.bin
+
+# Off-target unit test for bisect_geom.h (pure host math; no QMK, no hardware).
+test-bisect:
+	gcc -Wall -Wextra -Ilayouts/shofel/split_3x6_3/shofel -o /tmp/test_bisect_geom tools/test_bisect_geom.c -lm && /tmp/test_bisect_geom
 
 %:
 	+$(MAKE) -C $(QMK_FIRMWARE_ROOT) $(MAKECMDGOALS) QMK_USERSPACE=$(QMK_USERSPACE)

--- a/TODO.md
+++ b/TODO.md
@@ -21,16 +21,9 @@ TODO move to a docs
 - oneshot: allow press two oneshots at a time to schedule both
 TODO document a pitfall: the oneshot layer is not being stacked + explain why
 
-TODO next
-- mouse
-  - come up with keys to enable bisect and radial mouse modes
-    - use three top-row keys of the strong fingers on the left hand (, u c). The layer is mouse. comfort of the keys: u > c > ,
-      - , -> stock mode
-      - u -> radial mouse
-      - c -> bisect
-      - default is bisect
-  - bisect with digitizer. I see a digitizer in gnome settings. It should work now!. I mean the feature is about position the pointer like a binary search
-  - radial mouse by gautrier (plug his module)
+- mouse: radial mode (orbital_mouse) — deferred. It reuses the MS_* keycodes and
+  forces mousekeys off, so it can't coexist with stock. Revisit if willing to
+  drop stock. (Stock + bisect modes shipped — see docs/superpowers/specs.)
 
 - 88 bug: fast seq [os_sft c a] resolves to [C A], while [C a] expected
 - make ucis and unicodemap work together

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,16 @@
 # TODO
 
+TODO: for each layer: sync comment docs and code
+      - can we do it with a cheap and fast haiku?
+      - shall we do it as a follow-up for each PR/feature?
+
 ## Layout
 
+TODO: just remove this point. It's useful with plain yi+dt+{x . w}
 - leader seq for gui+L_NUM : leader,w
 
 ### Known / accepted
+TODO move to a docs
 - kitty control doesn't work while Ru active: leader,k sends win+T fine, but the
   follow-up control keys are typed on the Russian layer (come out Cyrillic).
   Not a leader bug (leader,k itself records correctly). Left as-is — fixing would
@@ -13,9 +19,19 @@
 ## Modules
 
 - oneshot: allow press two oneshots at a time to schedule both
-- 8 mouse
-  - bisect with digitizer. I see a digitizer in gnome settings. It should work now!
-  - radial mouse by gautrier
+TODO document a pitfall: the oneshot layer is not being stacked + explain why
+
+TODO next
+- mouse
+  - come up with keys to enable bisect and radial mouse modes
+    - use three top-row keys of the strong fingers on the left hand (, u c). The layer is mouse. comfort of the keys: u > c > ,
+      - , -> stock mode
+      - u -> radial mouse
+      - c -> bisect
+      - default is bisect
+  - bisect with digitizer. I see a digitizer in gnome settings. It should work now!. I mean the feature is about position the pointer like a binary search
+  - radial mouse by gautrier (plug his module)
+
 - 88 bug: fast seq [os_sft c a] resolves to [C A], while [C a] expected
 - make ucis and unicodemap work together
   - then: employ ucis for emoji: tulip and other flowers, tup=thumbup, ok, think, monocle

--- a/devenv.nix
+++ b/devenv.nix
@@ -2,7 +2,7 @@
 
 {
   # https://devenv.sh/packages/
-  packages = [ pkgs.qmk ];
+  packages = [ pkgs.qmk pkgs.dos2unix ];
 
   # To install qmk udev rules, add to your nixos configuration:
   # hardware.keyboard.qmk.enable = true;

--- a/docs/superpowers/specs/2026-07-06-mouse-modes-design.md
+++ b/docs/superpowers/specs/2026-07-06-mouse-modes-design.md
@@ -4,43 +4,40 @@ Date: 2026-07-06
 
 ## Goal
 
-Give the mouse layer three switchable **pointer modes**, selected from three
-top-row keys of the left hand's strong fingers (`,` `u` `c`, comfort u > c > ,):
+Give the mouse layer switchable **pointer modes**, selected from top-row keys of
+the left hand's strong fingers:
 
-- `,` (ring)  → **stock**  — the current QMK mousekeys (`MS_*`).
-- `u` (mid)   → **radial** — [getreuer's Orbital Mouse][om] community module (`OM_*`).
+- `,` (ring)  → **stock**  — the existing QMK mousekeys (`MS_*`), unchanged.
 - `c` (index) → **bisect** — binary-search absolute positioning via the QMK digitizer.
 
 **Default is bisect**: `leader,m` enters bisect every time (mode is not persisted).
 
-[om]: https://getreuer.info/posts/keyboards/orbital-mouse/index.html
+> **Radial mode (`u`) was dropped.** See "Radial — deferred" below.
 
-## Modes as three toggle sub-layers
+## Modes as toggle sub-layers
 
-Stock, radial and bisect each want their own *native* keycodes live on the layer
-(`MS_*`, `OM_*`, custom), so each mode is its own layer rather than one layer with
-a runtime flag:
+Stock and bisect each want their own native keycodes live on the layer (`MS_*`
+vs custom), so each mode is its own layer:
 
-    L_MOUSE          stock  (existing MS_* layer, unchanged except mode keys added)
-    L_MOUSE_RADIAL   radial (OM_* keys)
+    L_MOUSE          stock  (existing MS_* layer, + mode keys)
     L_MOUSE_BISECT   bisect (custom KK_BI_* keys)
 
-Layer count goes 6 → 8, which exactly fits `LAYER_STATE_8BIT`.
+Layer count goes 6 → 7 (fits `LAYER_STATE_8BIT`).
 
-These are ordinary **toggle layers** driven by the existing single-active-toggle
-system (`toggle_enable` / `toggle_disable`, one at a time, leader-masked). The three
-mode keys are custom keycodes present on **all three** sub-layers (top-left cols
-2/3/4, currently empty), each calling `toggle_enable(<its layer>)`. Switching mode
-therefore swaps the one active toggle layer. `leader,m` calls
-`toggle_enable(L_MOUSE_BISECT)`. Exit stays as today: Esc (shift+space combo) or
+These are ordinary **toggle layers** on the existing single-active-toggle system
+(`toggle_enable` / `toggle_disable`, one at a time, leader-masked). The two mode
+keys are custom keycodes (`KK_MM_STOCK`, `KK_MM_BISECT`) present on **both**
+sub-layers (top-left cols 2/4, `,` and `c`), each calling `toggle_enable(<its
+layer>)`. Switching mode swaps the one active toggle layer. `leader,m` calls
+`toggle_enable(L_MOUSE_BISECT)`. Exit is unchanged: Esc (shift+space combo) or
 `leader,space` → `toggle_disable` / `toggle_reset`.
 
 ## Bisect — algorithm
 
 Keep a normalized bounding box `{x0,x1,y0,y1}` in digitizer coordinates (0..1,
 origin top-left). Each halving key discards the far half along one axis and moves
-the absolute pointer to the **center of the surviving box** ("halve & re-center" —
-literal binary search):
+the absolute pointer to the **center of the surviving box** ("halve & re-center"
+— literal binary search):
 
     left   : x1 = (x0+x1)/2
     right  : x0 = (x0+x1)/2
@@ -49,42 +46,40 @@ literal binary search):
     reset  : box = full screen
     (after every one) digitizer_set_position((x0+x1)/2, (y0+y1)/2)
 
-Key placement on `L_MOUSE_BISECT` mirrors the stock arrow cluster (right hand):
-up / left / down / right for the four halvings, index = **click**, plus a **reset**
-key. Click holds the digitizer tip switch (down on press, up on release) — a real
-click duration, drag-capable.
-
-The box geometry is pure integer-free float math extracted into a header-only
-module `bisect_geom.h`, unit-tested off-target (see Testing).
+Keys mirror the stock arrow cluster (right hand): up / left / down / right for
+the four halvings, index = **click**, plus a **reset** key. Click holds the
+digitizer tip switch (down on press, up on release) — a real click duration,
+drag-capable. The box math lives in header-only `bisect_geom.h`, unit-tested
+off-target (see Testing).
 
 ## Enter / exit hook
 
 `layer_state_set_user` watches `L_MOUSE_BISECT`:
 
 - became active   → `digitizer_in_range_on()`, reset box, center pointer.
-- became inactive → `digitizer_in_range_off()`.
+- became inactive → release a held tip, then `digitizer_in_range_off()`.
 
-This fires however the layer is left (mode switch, Esc, `leader,space`), so the
-digitizer is always released when leaving bisect.
+Fires however the layer is left (mode switch, Esc, `leader,space`), so the
+digitizer is always released when leaving bisect. Outside bisect the digitizer
+is out of range, so the host ignores it and normal input is unaffected.
 
-## Radial — Orbital Mouse integration
+## Radial — deferred
 
-- Vendor `getreuer/qmk-modules` as a git submodule at `modules/getreuer`
-  (upstream-prescribed install; the repo's own `shofel/*` modules stay in-tree).
-- Register `"getreuer/orbital_mouse"` in `keymap.json` `modules`.
-- `L_MOUSE_RADIAL` uses `OM_U/OM_D` (move along heading), `OM_L/OM_R` (steer),
-  `OM_BTN1/2`, wheel `OM_W_*`, mapped onto the mouse layout.
-- Keep `MOUSEKEY_ENABLE = yes` (stock mode needs it); orbital coexists.
-- Requires QMK community modules (≥ 0.28.0). Build note: `git submodule update
-  --init` after clone.
+The plan was to add a radial/polar mode via getreuer's Orbital Mouse community
+module (`getreuer/orbital_mouse`). Dropped after inspecting the module: its
+`OM_*` keycodes are **aliases of the `MS_*` mousekeys** (`OM_U == MS_UP`, …) and
+its `qmk_module.json` sets `"mousekey": false` — it *replaces* QMK mousekeys and
+repurposes their keycodes. So "stock mousekeys" and "orbital radial" cannot both
+be live modes in one firmware. Keeping true stock mousekeys (with the tuned
+`MK_*` config) was chosen over radial. Revisit only if willing to drop stock, in
+which case orbital's cardinal (`OM_CS_*`) keys can stand in for a stock-like feel.
 
 ## Testing
 
 - **Unit (off-target, test-first):** `tools/test_bisect_geom.c` compiles
   `bisect_geom.h` with plain `gcc` and asserts halving sequences + centers,
-  including axis direction (catches an inverted up/down). Run: `make test-bisect`
-  (or `gcc` one-liner documented in the test).
-- **Compile:** `make build` must compile cleanly (verification bar for this PR).
+  including axis direction. Run: `make test-bisect`.
+- **Compile:** `make build` compiles cleanly (verification bar for this PR).
 - **Hardware QA (owner: user):** flash (`make flash`) and physically verify on the
   Cantor. Automated tests cannot validate real pointer behavior.
 
@@ -95,12 +90,11 @@ digitizer is always released when leaving bisect.
    (one line). Flagged, not pre-solved.
 2. **Multi-monitor:** the host maps 0..1 across the whole virtual desktop, so
    "center" is the middle of all displays, not the focused one.
-3. **Orbital feel / speed curve** is tunable in `config.h` after trying it.
-4. **Flash size:** mousekeys + orbital + digitizer together; LTO is on. `make build`
-   confirms it fits.
+3. **Flash size:** mousekeys + digitizer together; LTO is on. `make build` confirms
+   it fits (≈37.8 KB).
 
 ## Out of scope
 
-- No auto-reset of the bisect box after a click (reset is one key; keeps it
-  predictable). Revisit if QA wants it.
+- No auto-reset of the bisect box after a click (reset is one key; predictable).
 - No persistence of the last-used mode (always start in bisect, by request).
+- `u` is unused on the mouse layers (was to be radial).

--- a/docs/superpowers/specs/2026-07-06-mouse-modes-design.md
+++ b/docs/superpowers/specs/2026-07-06-mouse-modes-design.md
@@ -1,0 +1,106 @@
+# Mouse modes — design
+
+Date: 2026-07-06
+
+## Goal
+
+Give the mouse layer three switchable **pointer modes**, selected from three
+top-row keys of the left hand's strong fingers (`,` `u` `c`, comfort u > c > ,):
+
+- `,` (ring)  → **stock**  — the current QMK mousekeys (`MS_*`).
+- `u` (mid)   → **radial** — [getreuer's Orbital Mouse][om] community module (`OM_*`).
+- `c` (index) → **bisect** — binary-search absolute positioning via the QMK digitizer.
+
+**Default is bisect**: `leader,m` enters bisect every time (mode is not persisted).
+
+[om]: https://getreuer.info/posts/keyboards/orbital-mouse/index.html
+
+## Modes as three toggle sub-layers
+
+Stock, radial and bisect each want their own *native* keycodes live on the layer
+(`MS_*`, `OM_*`, custom), so each mode is its own layer rather than one layer with
+a runtime flag:
+
+    L_MOUSE          stock  (existing MS_* layer, unchanged except mode keys added)
+    L_MOUSE_RADIAL   radial (OM_* keys)
+    L_MOUSE_BISECT   bisect (custom KK_BI_* keys)
+
+Layer count goes 6 → 8, which exactly fits `LAYER_STATE_8BIT`.
+
+These are ordinary **toggle layers** driven by the existing single-active-toggle
+system (`toggle_enable` / `toggle_disable`, one at a time, leader-masked). The three
+mode keys are custom keycodes present on **all three** sub-layers (top-left cols
+2/3/4, currently empty), each calling `toggle_enable(<its layer>)`. Switching mode
+therefore swaps the one active toggle layer. `leader,m` calls
+`toggle_enable(L_MOUSE_BISECT)`. Exit stays as today: Esc (shift+space combo) or
+`leader,space` → `toggle_disable` / `toggle_reset`.
+
+## Bisect — algorithm
+
+Keep a normalized bounding box `{x0,x1,y0,y1}` in digitizer coordinates (0..1,
+origin top-left). Each halving key discards the far half along one axis and moves
+the absolute pointer to the **center of the surviving box** ("halve & re-center" —
+literal binary search):
+
+    left   : x1 = (x0+x1)/2
+    right  : x0 = (x0+x1)/2
+    up     : y1 = (y0+y1)/2      (origin is top, so "up" keeps the smaller y)
+    down   : y0 = (y0+y1)/2
+    reset  : box = full screen
+    (after every one) digitizer_set_position((x0+x1)/2, (y0+y1)/2)
+
+Key placement on `L_MOUSE_BISECT` mirrors the stock arrow cluster (right hand):
+up / left / down / right for the four halvings, index = **click**, plus a **reset**
+key. Click holds the digitizer tip switch (down on press, up on release) — a real
+click duration, drag-capable.
+
+The box geometry is pure integer-free float math extracted into a header-only
+module `bisect_geom.h`, unit-tested off-target (see Testing).
+
+## Enter / exit hook
+
+`layer_state_set_user` watches `L_MOUSE_BISECT`:
+
+- became active   → `digitizer_in_range_on()`, reset box, center pointer.
+- became inactive → `digitizer_in_range_off()`.
+
+This fires however the layer is left (mode switch, Esc, `leader,space`), so the
+digitizer is always released when leaving bisect.
+
+## Radial — Orbital Mouse integration
+
+- Vendor `getreuer/qmk-modules` as a git submodule at `modules/getreuer`
+  (upstream-prescribed install; the repo's own `shofel/*` modules stay in-tree).
+- Register `"getreuer/orbital_mouse"` in `keymap.json` `modules`.
+- `L_MOUSE_RADIAL` uses `OM_U/OM_D` (move along heading), `OM_L/OM_R` (steer),
+  `OM_BTN1/2`, wheel `OM_W_*`, mapped onto the mouse layout.
+- Keep `MOUSEKEY_ENABLE = yes` (stock mode needs it); orbital coexists.
+- Requires QMK community modules (≥ 0.28.0). Build note: `git submodule update
+  --init` after clone.
+
+## Testing
+
+- **Unit (off-target, test-first):** `tools/test_bisect_geom.c` compiles
+  `bisect_geom.h` with plain `gcc` and asserts halving sequences + centers,
+  including axis direction (catches an inverted up/down). Run: `make test-bisect`
+  (or `gcc` one-liner documented in the test).
+- **Compile:** `make build` must compile cleanly (verification bar for this PR).
+- **Hardware QA (owner: user):** flash (`make flash`) and physically verify on the
+  Cantor. Automated tests cannot validate real pointer behavior.
+
+## Known risks — resolve at hardware QA
+
+1. **Digitizer tap == left click?** GNOME may treat a digitizer tip tap differently
+   from a mouse button click in some apps. If so, swap the click key to `MS_BTN1`
+   (one line). Flagged, not pre-solved.
+2. **Multi-monitor:** the host maps 0..1 across the whole virtual desktop, so
+   "center" is the middle of all displays, not the focused one.
+3. **Orbital feel / speed curve** is tunable in `config.h` after trying it.
+4. **Flash size:** mousekeys + orbital + digitizer together; LTO is on. `make build`
+   confirms it fits.
+
+## Out of scope
+
+- No auto-reset of the bisect box after a click (reset is one key; keeps it
+  predictable). Revisit if QA wants it.
+- No persistence of the last-used mode (always start in bisect, by request).

--- a/layouts/shofel/split_3x6_3/shofel/bisect_geom.h
+++ b/layouts/shofel/split_3x6_3/shofel/bisect_geom.h
@@ -1,0 +1,28 @@
+/* Pure geometry for bisect mouse mode: a normalized bounding box in digitizer
+ * coordinates (0..1, origin top-left). Header-only and QMK-free so it can be
+ * unit-tested off-target (see tools/test_bisect_geom.c).
+ *
+ * Each halving discards the far half along one axis; the caller then moves the
+ * absolute pointer to (bisect_cx, bisect_cy) — the center of the surviving box.
+ */
+#pragma once
+
+typedef struct {
+    float x0, x1, y0, y1;
+} bisect_box_t;
+
+static inline void bisect_reset(bisect_box_t *b) {
+    b->x0 = 0.0f;
+    b->x1 = 1.0f;
+    b->y0 = 0.0f;
+    b->y1 = 1.0f;
+}
+
+static inline void bisect_left(bisect_box_t *b)  { b->x1 = (b->x0 + b->x1) * 0.5f; }
+static inline void bisect_right(bisect_box_t *b) { b->x0 = (b->x0 + b->x1) * 0.5f; }
+/* Origin is top-left: "up" keeps the smaller-y (top) half, "down" the larger-y. */
+static inline void bisect_up(bisect_box_t *b)    { b->y1 = (b->y0 + b->y1) * 0.5f; }
+static inline void bisect_down(bisect_box_t *b)  { b->y0 = (b->y0 + b->y1) * 0.5f; }
+
+static inline float bisect_cx(const bisect_box_t *b) { return (b->x0 + b->x1) * 0.5f; }
+static inline float bisect_cy(const bisect_box_t *b) { return (b->y0 + b->y1) * 0.5f; }

--- a/layouts/shofel/split_3x6_3/shofel/keymap.c
+++ b/layouts/shofel/split_3x6_3/shofel/keymap.c
@@ -7,6 +7,8 @@
 #include QMK_KEYBOARD_H
 #include "introspection.h"
 #include "modules/shofel/unicode_ru/introspection.h"
+#include "digitizer.h"
+#include "bisect_geom.h"
 
 /*
  * Runtime debug logging — all off by default.
@@ -36,6 +38,18 @@ enum my_keycodes {
   OS_ALT,
   OS_GUI,
   OS_SFT,
+
+  /* Mouse mode switch (live on the mouse layers) */
+  KK_MM_STOCK,
+  KK_MM_BISECT,
+
+  /* Bisect mode actions */
+  KK_BI_L,
+  KK_BI_R,
+  KK_BI_U,
+  KK_BI_D,
+  KK_BI_CLICK,
+  KK_BI_RESET,
 };
 
 /* Layer names */
@@ -46,6 +60,7 @@ enum my_layer_names {
   L_NUM_NAV,
   L_FKEYS_SYS,
   L_MOUSE,
+  L_MOUSE_BISECT,
 };
 
 /* Simple thumb keys. */
@@ -369,7 +384,7 @@ void leader_end_user(void) {
     toggle_enable(L_FKEYS_SYS);
   }
   if (leader_sequence_one_key(KC_M)) {
-    toggle_enable(L_MOUSE);
+    toggle_enable(L_MOUSE_BISECT);
   }
   if (leader_sequence_one_key(KC_T)) {
     toggle_enable(L_NUM_NAV);
@@ -399,6 +414,15 @@ void leader_end_user(void) {
   }
 
   /* UCIS emoji — disabled (module conflict with unicodemap) */
+}
+
+/* Mouse: bisect mode — binary-search absolute positioning via the digitizer.
+ * The box lives here; layer_state_set_user arms/releases the digitizer when
+ * entering/leaving L_MOUSE_BISECT. */
+static bisect_box_t bi_box;
+
+static void bisect_move(void) {
+  digitizer_set_position(bisect_cx(&bi_box), bisect_cy(&bi_box));
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -447,11 +471,58 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         }
       }
       return false;
+
+    /* Mouse mode switch */
+    case KK_MM_STOCK:
+      if (record->event.pressed) { toggle_enable(L_MOUSE); }
+      return false;
+    case KK_MM_BISECT:
+      if (record->event.pressed) { toggle_enable(L_MOUSE_BISECT); }
+      return false;
+
+    /* Bisect: halve the box and re-center the pointer; click holds the tip. */
+    case KK_BI_L:
+      if (record->event.pressed) { bisect_left(&bi_box);  bisect_move(); }
+      return false;
+    case KK_BI_R:
+      if (record->event.pressed) { bisect_right(&bi_box); bisect_move(); }
+      return false;
+    case KK_BI_U:
+      if (record->event.pressed) { bisect_up(&bi_box);    bisect_move(); }
+      return false;
+    case KK_BI_D:
+      if (record->event.pressed) { bisect_down(&bi_box);  bisect_move(); }
+      return false;
+    case KK_BI_RESET:
+      if (record->event.pressed) { bisect_reset(&bi_box); bisect_move(); }
+      return false;
+    case KK_BI_CLICK:
+      if (record->event.pressed) { digitizer_tip_switch_on(); }
+      else                       { digitizer_tip_switch_off(); }
+      return false;
+
     default:
       break;
   }
 
   return true;
+}
+
+/* Arm the digitizer while in bisect mode; release it on the way out (however
+ * the layer is left — mode switch, Esc, or leader,space). */
+layer_state_t layer_state_set_user(layer_state_t state) {
+  static bool bisect_was_on = false;
+  bool bisect_on = layer_state_cmp(state, L_MOUSE_BISECT);
+  if (bisect_on && !bisect_was_on) {
+    digitizer_in_range_on();
+    bisect_reset(&bi_box);
+    bisect_move();
+  } else if (!bisect_on && bisect_was_on) {
+    digitizer_tip_switch_off();  // release a held click before leaving
+    digitizer_in_range_off();
+  }
+  bisect_was_on = bisect_on;
+  return state;
 }
 
 /**
@@ -644,21 +715,46 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   /**
-   * Mouse layer.
+   * Mouse layer — STOCK mode (QMK mousekeys).
    *
-   * Activated by Leader,m (sticky). Exit with Esc (shift+space combo) or Leader,space.
+   * Reached via Leader,m, which starts in BISECT. Top-row left keys switch mode:
+   *   `,` = stock (this layer)   `c` = bisect.
+   * Exit any mouse mode with Esc (shift+space combo) or Leader,space.
    *
    * Left hand can apply modifiers, to perform shift+click, or ctrl+wheelup.
+   * (a2/a0/a1 = mousekey acceleration MS_ACL2/0/1.)
    */
   [L_MOUSE] = LAYOUT_split_3x6_3(/*
-        __  a2  __  __  __  __                       __  w↑  ↑  w↓  __  __
-        __  a1  __  __  __  __                       __  <-  c  ->  b2  __
-        __  a0  __  __  __  __                       __  b3  ↓  __  __  __
+        __  __  stk __  bis __                       __  w↑  ↑   w↓  __  __
+        __  __  a2  a0  a1  __                       __  <-  b1  ->  b2  __
+        __  __  __  __  __  __                       __  b3  ↓   __  __  __
                              __  __  __     __  __  __
        */
-        XX,      XX,        XX,       XX,      XX,  XX,       XX, MS_WHLU,  MS_UP  ,  MS_WHLD,      XX,  XX,
-        XX,      XX,   MS_ACL2,  MS_ACL0, MS_ACL1,  XX,       XX, MS_LEFT,  MS_BTN1,  MS_RGHT, MS_BTN2,  __,
-        XX,      XX,        XX,       XX,      XX,  XX,       XX, MS_BTN3,  MS_DOWN,       XX,      XX,  XX,
+        XX, XX, KK_MM_STOCK,      XX, KK_MM_BISECT, XX,   XX, MS_WHLU, MS_UP  , MS_WHLD,      XX, XX,
+        XX, XX,     MS_ACL2, MS_ACL0,      MS_ACL1, XX,   XX, MS_LEFT, MS_BTN1, MS_RGHT, MS_BTN2, __,
+        XX, XX,          XX,      XX,           XX, XX,   XX, MS_BTN3, MS_DOWN,      XX,      XX, XX,
+
+                                   __ ,    __ ,   __ ,         __ ,  __ ,  __
+  ),
+
+  /**
+   * Mouse layer — BISECT mode (digitizer binary search). DEFAULT via Leader,m.
+   *
+   * Pointer starts at screen center. The right-hand arrow cross halves the
+   * screen and re-centers each press:  ↑=up  <-=left  ->=right  ↓=down.
+   * clk = click (holds the digitizer tip; hold to drag).  rst = reset to full
+   * screen.  `,` switches to stock. Leaving bisect releases the digitizer
+   * (layer_state_set_user).
+   */
+  [L_MOUSE_BISECT] = LAYOUT_split_3x6_3(/*
+        __  __  stk __  bis __                       __  __  ↑    __   __  __
+        __  __  __  __  __  __                       __  <-  clk  ->   rst __
+        __  __  __  __  __  __                       __  __  ↓    __   __  __
+                             __  __  __     __  __  __
+       */
+        XX, XX, KK_MM_STOCK, XX, KK_MM_BISECT, XX,   XX,      XX,     KK_BI_U,      XX,          XX, XX,
+        XX, XX,          XX, XX,           XX, XX,   XX, KK_BI_L, KK_BI_CLICK, KK_BI_R, KK_BI_RESET, __,
+        XX, XX,          XX, XX,           XX, XX,   XX,      XX,     KK_BI_D,      XX,          XX, XX,
 
                                    __ ,    __ ,   __ ,         __ ,  __ ,  __
   ),

--- a/layouts/shofel/split_3x6_3/shofel/keymap.c
+++ b/layouts/shofel/split_3x6_3/shofel/keymap.c
@@ -587,12 +587,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
    */
   [L_SYMBOLS] = LAYOUT_split_3x6_3(/*
        ·  `   —   $   ^   ·                        ·   !   *   |   &   /
-       ·      ~   @   #   ·                        ·   ?   :   +   %   -
+       ·      ~   @   #   ·                        ·   :   ?   +   %   -
        ·  ·   №   §   \   ⌦                        ⌫   =   ;           ·
                             __  __  SYM   __  __  __
        */
         XX,  KC_GRV, RU_MDASH,   KC_DLR, KC_CIRC,      XX,            XX,  KC_EXLM,  KC_ASTR,  KC_PIPE, KC_AMPR,  KC_SLASH,
-        XX,      XX,  KC_TILD,    KC_AT, KC_HASH,      XX,            XX,  KC_QUES,  KC_COLN,  KC_PLUS, KC_PERC,  KC_MINUS,
+        XX,      XX,  KC_TILD,    KC_AT, KC_HASH,      XX,            XX,  KC_COLN,  KC_QUES,  KC_PLUS, KC_PERC,  KC_MINUS,
         XX,      XX,   RU_NUM,  RU_SECT, KC_BSLS,  KC_DEL,       KC_BSPC,   KC_EQL,  KC_SCLN,       XX,      XX,  XX,
                                       __ ,  __ , KK_SYMBO,         __ ,  __ ,  __
   ),

--- a/tools/test_bisect_geom.c
+++ b/tools/test_bisect_geom.c
@@ -1,0 +1,68 @@
+/* Off-target unit test for bisect_geom.h — the pure box math behind bisect
+ * mouse mode. No QMK deps, so it runs on the host.
+ *
+ * Build & run from the repo root:
+ *   gcc -Wall -Wextra -Ilayouts/shofel/split_3x6_3/shofel \
+ *       -o /tmp/test_bisect_geom tools/test_bisect_geom.c -lm && /tmp/test_bisect_geom
+ * or:  make test-bisect
+ */
+#include <math.h>
+#include <stdio.h>
+#include "bisect_geom.h"
+
+static int failures = 0;
+
+static void check(const char *name, float got, float want) {
+    if (fabsf(got - want) > 1e-6f) {
+        printf("FAIL %s: got %.6f want %.6f\n", name, got, want);
+        failures++;
+    } else {
+        printf("ok   %s = %.6f\n", name, got);
+    }
+}
+
+int main(void) {
+    bisect_box_t b;
+
+    /* Full screen centers the pointer. */
+    bisect_reset(&b);
+    check("reset cx", bisect_cx(&b), 0.5f);
+    check("reset cy", bisect_cy(&b), 0.5f);
+
+    /* One halving per axis, re-centered into the surviving half. */
+    bisect_reset(&b); bisect_right(&b);
+    check("right cx", bisect_cx(&b), 0.75f);
+    check("right cy unchanged", bisect_cy(&b), 0.5f);
+
+    bisect_reset(&b); bisect_left(&b);
+    check("left cx", bisect_cx(&b), 0.25f);
+
+    /* Origin is top-left, so "up" keeps the SMALLER-y (top) half. */
+    bisect_reset(&b); bisect_up(&b);
+    check("up cy", bisect_cy(&b), 0.25f);
+    check("up cx unchanged", bisect_cx(&b), 0.5f);
+
+    bisect_reset(&b); bisect_down(&b);
+    check("down cy", bisect_cy(&b), 0.75f);
+
+    /* Two axes drill into a quadrant. */
+    bisect_reset(&b); bisect_right(&b); bisect_up(&b);
+    check("right+up cx", bisect_cx(&b), 0.75f);
+    check("right+up cy", bisect_cy(&b), 0.25f);
+
+    /* Repeated halving on one axis keeps narrowing. */
+    bisect_reset(&b); bisect_right(&b); bisect_right(&b);
+    check("right x2 cx", bisect_cx(&b), 0.875f);
+
+    /* Reset undoes all narrowing. */
+    bisect_reset(&b); bisect_left(&b); bisect_down(&b); bisect_reset(&b);
+    check("reset restores cx", bisect_cx(&b), 0.5f);
+    check("reset restores cy", bisect_cy(&b), 0.5f);
+
+    if (failures) {
+        printf("\n%d FAILURE(S)\n", failures);
+        return 1;
+    }
+    printf("\nAll bisect_geom tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## ⚠️ Needs hardware QA before merge — do not merge until flashed & tested on the Cantor.

Implements the marked "mouse modes" TODO item. Built via the engineer-mini pipeline (spec → TDD → review → docs).

## What shipped
Two mouse modes on the mouse layer, switched from the left top-row keys; `leader,m` enters **bisect** by default:

- **`,` → stock** — the existing QMK mousekeys, unchanged (keeps your tuned `MK_*` config).
- **`c` → bisect** — binary-search absolute positioning via the QMK **digitizer**. Pointer starts at screen center; the right-hand arrow cross halves the screen and re-centers each press (↑/←/→/↓); index = **click** (holds the digitizer tip, drag-capable); a reset key restores full screen. Leaving bisect releases the digitizer.

## Radial deferred (was `u`)
Orbital Mouse (`getreuer/orbital_mouse`) turned out to **alias the `MS_*` mousekeys** and force mousekeys off — so "stock mousekeys" and "orbital radial" can’t coexist. Per your call, kept true stock + bisect; radial revisitable if ever willing to drop stock. Rationale recorded in `docs/superpowers/specs/2026-07-06-mouse-modes-design.md`.

## Verification
- `make build` — compiles clean (≈37.8 KB). **Compilation is the only automated bar; it cannot validate real pointer behavior.**
- `make test-bisect` — off-target unit test for the bisect box math (written test-first, red→green).

## Hardware QA checklist (please run before merging)
- [ ] `make flash` (double-tap reset first).
- [ ] `leader,m` → pointer jumps to screen center (bisect).
- [ ] Arrow cross halves toward the target; a few presses land on a small UI element.
- [ ] Index key clicks at the pointer; reset returns to full screen.
- [ ] `,` switches to stock mousekeys; `c` back to bisect.
- [ ] Esc (shift+space) / `leader,space` exits and the pointer behaves normally afterward (digitizer released).

### QA risks to watch (see spec)
1. **Digitizer tip-tap vs left click** — GNOME may treat the tap differently in some apps. If so, swap `KK_BI_CLICK` to `MS_BTN1` (one line).
2. **Multi-monitor** — 0..1 maps across the whole virtual desktop, so "center" is the middle of all displays.

## Note
Branch is off local `main`, so this PR also carries earlier unpushed commits (`layout: swap ? and :`, `build: dos2unix`, `docs(todo): mark next items`). They land when this (or the docs PR) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)